### PR TITLE
EntryKitのビルド

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,12 +3,24 @@ FROM ruby:2.6.5
 ENV LANG C.UTF-8
 ENV ENTRYKIT_VERSION 0.4.0
 
-RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-  && tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-  && rm entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
+RUN apt-get update -qq \
+  && apt-get install -y golang
+
+RUN wget -O entrykit.tar.gz https://github.com/progrium/entrykit/archive/v${ENTRYKIT_VERSION}.tar.gz \
+  && tar -zxvf entrykit.tar.gz \
+  && rm entrykit.tar.gz \
+  && cd entrykit-${ENTRYKIT_VERSION} \
+  && go mod init go-tools \
+  && go mod tidy \
+  && go build ./... \
+  && go build -a -installsuffix cgo -ldflags "-X main.Version=${ENTRYKIT_VERSION}" -o entrykit ./cmd \
   && mv entrykit /bin/entrykit \
   && chmod +x /bin/entrykit \
-  && entrykit --symlink
+  && entrykit --symlink \
+  && cd .. \
+  && rm -rf entrykit-${ENTRYKIT_VERSION} \
+  && apt-get remove --purge -y golang \
+  && apt-get -y autoremove
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \


### PR DESCRIPTION
https://github.com/progrium/entrykit/releases にaarch64(arm64)用のバイナリは提供されていなくて困ったので
goの作法詳しくなくて変なことしてるかもしれない